### PR TITLE
Fixes for Python 3.

### DIFF
--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -66,7 +66,7 @@ class Encoder(object):
         elif isinstance(typ, DictionaryType):
             msg = KRPC.Dictionary()
             entries = []
-            for key, value in sorted(x.items(), key=lambda i: i[0]):
+            for key, value in sorted(list(x.items()), key=lambda i: i[0]):
                 entry = KRPC.DictionaryEntry()
                 entry.key = cls.encode(key, typ.key_type)
                 entry.value = cls.encode(value, typ.value_type)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -192,7 +192,7 @@ def create_service(client, service):
                 properties[name][0] = procedure
             else:
                 properties[name][1] = procedure
-    for name, procedures in properties.items():
+    for name, procedures in list(properties.items()):
         cls._add_service_property(name, procedures[0], procedures[1])
 
     # Add class methods
@@ -221,7 +221,7 @@ def create_service(client, service):
                 properties[key][0] = procedure
             else:
                 properties[key][1] = procedure
-    for (class_name, property_name), procedures in properties.items():
+    for (class_name, property_name), procedures in list(properties.items()):
         cls._add_service_class_property(
             class_name, property_name, procedures[0], procedures[1])
 

--- a/client/python/krpc/test/test_attributes.py
+++ b/client/python/krpc/test/test_attributes.py
@@ -16,7 +16,7 @@ class TestAttributes(unittest.TestCase):
 
     def check(self, method, *returnsTrue):
         for case in self.cases:
-            self.assertEquals(case in returnsTrue, method(case))
+            self.assertEqual(case in returnsTrue, method(case))
 
     def test_is_a_procedure(self):
         self.check(Attributes.is_a_procedure, 'ProcedureName')

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -12,7 +12,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
 
     def test_get_status(self):
         status = self.conn.krpc.get_status()
-        self.assertRegexpMatches(status.version, r'^[0-9]+\.[0-9]+\.[0-9]+$')
+        self.assertRegex(status.version, r'^[0-9]+\.[0-9]+\.[0-9]+$')
         self.assertGreater(status.bytes_read, 0)
 
     def test_wrong_rpc_port(self):
@@ -61,7 +61,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
         self.assertEqual('42',
                          self.conn.test_service.int32_to_string(42))
         self.assertEqual('123456789000',
-                         self.conn.test_service.int64_to_string(123456789000L))
+                         self.conn.test_service.int64_to_string(123456789000))
         self.assertEqual('True',
                          self.conn.test_service.bool_to_string(True))
         self.assertEqual('False',
@@ -79,9 +79,9 @@ class TestClient(ServerTestCase, unittest.TestCase):
 
     def test_auto_value_type_conversion(self):
         self.assertEqual('42', self.conn.test_service.float_to_string(42))
-        self.assertEqual('42', self.conn.test_service.float_to_string(42L))
+        self.assertEqual('42', self.conn.test_service.float_to_string(42))
         self.assertEqual(
-            '6', self.conn.test_service.add_multiple_values(1L, 2L, 3L))
+            '6', self.conn.test_service.add_multiple_values(1, 2, 3))
         self.assertRaises(
             TypeError, self.conn.test_service.float_to_string, '42')
 

--- a/client/python/krpc/test/test_connection.py
+++ b/client/python/krpc/test/test_connection.py
@@ -88,7 +88,7 @@ class TestConnection(unittest.TestCase):
     def test_partial_receive_on_remote_closed_connection(self):
         conn = self.connect()
         self.server_close_connection(conn)
-        self.assertEquals(b'', conn.partial_receive(1))
+        self.assertEqual(b'', conn.partial_receive(1))
 
     def test_send_on_closed_connection(self):
         conn = self.connect()

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -66,7 +66,7 @@ class TestEncodeDecode(unittest.TestCase):
             (1, '02'),
             (42, '54'),
             (300, 'd804'),
-            (1234567890000L, 'a091d89fee47'),
+            (1234567890000, 'a091d89fee47'),
             (-33, '41')
         ]
         self._run_test_encode_value(self.types.sint64_type, cases)
@@ -78,7 +78,7 @@ class TestEncodeDecode(unittest.TestCase):
             (1, '01'),
             (42, '2a'),
             (300, 'ac02'),
-            (sys.maxint, 'ffffffffffffffff7f')
+            (sys.maxsize, 'ffffffffffffffff7f')
         ]
         self._run_test_encode_value(self.types.uint32_type, cases)
         self._run_test_decode_value(self.types.uint32_type, cases)
@@ -94,7 +94,7 @@ class TestEncodeDecode(unittest.TestCase):
             (1, '01'),
             (42, '2a'),
             (300, 'ac02'),
-            (1234567890000L, 'd088ec8ff723')
+            (1234567890000, 'd088ec8ff723')
         ]
         self._run_test_encode_value(self.types.uint64_type, cases)
         self._run_test_decode_value(self.types.uint64_type, cases)

--- a/client/python/krpc/test/test_performance.py
+++ b/client/python/krpc/test/test_performance.py
@@ -17,9 +17,9 @@ class TestPerformance(ServerTestCase, unittest.TestCase):
 
         delta_t = timeit.timeit(stmt=wrapper, number=samples)
         print()
-        print('Total execution time: %.2f seconds' % delta_t)
-        print('RPC execution rate: %d per second' % (samples/delta_t))
-        print('Latency: %.3f milliseconds' % ((delta_t*1000)/samples))
+        print(('Total execution time: %.2f seconds' % delta_t))
+        print(('RPC execution rate: %d per second' % (samples/delta_t)))
+        print(('Latency: %.3f milliseconds' % ((delta_t*1000)/samples)))
 
 
 if __name__ == '__main__':

--- a/client/python/krpc/test/test_performance.py
+++ b/client/python/krpc/test/test_performance.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import unittest
 import timeit
 from krpc.test.servertestcase import ServerTestCase

--- a/client/python/krpc/test/test_platform.py
+++ b/client/python/krpc/test/test_platform.py
@@ -7,7 +7,7 @@ class TestPlatform(unittest.TestCase):
         self.assertEqual(0, bytelength(''))
         self.assertEqual(3, bytelength('foo'))
         self.assertEqual(3, bytelength(b'\xe2\x84\xa2'.decode('utf-8')))
-        self.assertEqual(3, bytelength('\u2122'))
+        self.assertEqual(3, bytelength('\\u2122'))
 
     def test_hexlify(self):
         self.assertEqual(hexlify(b''), '')

--- a/client/python/krpc/test/test_platform.py
+++ b/client/python/krpc/test/test_platform.py
@@ -7,7 +7,7 @@ class TestPlatform(unittest.TestCase):
         self.assertEqual(0, bytelength(''))
         self.assertEqual(3, bytelength('foo'))
         self.assertEqual(3, bytelength(b'\xe2\x84\xa2'.decode('utf-8')))
-        self.assertEqual(3, bytelength(u'\u2122'))
+        self.assertEqual(3, bytelength('\u2122'))
 
     def test_hexlify(self):
         self.assertEqual(hexlify(b''), '')

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -342,7 +342,7 @@ class TestStream(ServerTestCase, unittest.TestCase):
 
         self.assertTrue(stop.is_set())
         self.assertFalse(error.is_set())
-        self.assertEquals(self.test_callback_value, 5)
+        self.assertEqual(self.test_callback_value, 5)
 
     def test_remove_callback(self):
         called1 = threading.Event()

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -27,9 +27,9 @@ class TestTypes(unittest.TestCase):
             (types.double_type, Type.DOUBLE, float),
             (types.float_type, Type.FLOAT, float),
             (types.sint32_type, Type.SINT32, int),
-            (types.sint64_type, Type.SINT64, long),
+            (types.sint64_type, Type.SINT64, int),
             (types.uint32_type, Type.UINT32, int),
-            (types.uint64_type, Type.UINT64, long),
+            (types.uint64_type, Type.UINT64, int),
             (types.bool_type, Type.BOOL, bool),
             (types.string_type, Type.STRING, str),
             (types.bytes_type, Type.BYTES, bytes)
@@ -71,12 +71,12 @@ class TestTypes(unittest.TestCase):
         })
         self.assertTrue(issubclass(typ.python_type, Enum))
         self.assertEqual('enum documentation', typ.python_type.__doc__)
-        self.assertEquals(0, typ.python_type.a.value)
-        self.assertEquals(42, typ.python_type.b.value)
-        self.assertEquals(100, typ.python_type.c.value)
-        self.assertEquals('doca', typ.python_type.a.__doc__)
-        self.assertEquals('docb', typ.python_type.b.__doc__)
-        self.assertEquals('docc', typ.python_type.c.__doc__)
+        self.assertEqual(0, typ.python_type.a.value)
+        self.assertEqual(42, typ.python_type.b.value)
+        self.assertEqual(100, typ.python_type.c.value)
+        self.assertEqual('doca', typ.python_type.a.__doc__)
+        self.assertEqual('docb', typ.python_type.b.__doc__)
+        self.assertEqual('docc', typ.python_type.c.__doc__)
         typ2 = types.as_type(typ.protobuf_type)
         self.assertEqual(typ, typ2)
 
@@ -149,7 +149,7 @@ class TestTypes(unittest.TestCase):
         self.assertTrue(isinstance(typ.value_types[1], ValueType))
         self.assertTrue(isinstance(typ.value_types[2], ValueType))
         self.assertEqual(float, typ.value_types[0].python_type)
-        self.assertEqual(long, typ.value_types[1].python_type)
+        self.assertEqual(int, typ.value_types[1].python_type)
         self.assertEqual(str, typ.value_types[2].python_type)
         self.check_protobuf_type(
             Type.FLOAT, '', '', 0, typ.value_types[0].protobuf_type)
@@ -212,13 +212,13 @@ class TestTypes(unittest.TestCase):
             (42.0, 42, types.double_type),
             (42.0, 42, types.float_type),
             (42, 42.0, types.sint32_type),
-            (42, 42L, types.sint32_type),
-            (42L, 42.0, types.sint64_type),
-            (42L, 42, types.sint64_type),
+            (42, 42, types.sint32_type),
+            (42, 42.0, types.sint64_type),
+            (42, 42, types.sint64_type),
             (42, 42.0, types.uint32_type),
-            (42, 42L, types.uint32_type),
-            (42L, 42.0, types.uint64_type),
-            (42L, 42, types.uint64_type),
+            (42, 42, types.uint32_type),
+            (42, 42.0, types.uint64_type),
+            (42, 42, types.uint64_type),
             (list(), tuple(), types.list_type(types.string_type)),
             ((0, 1, 2), [0, 1, 2],
              types.tuple_type(types.sint32_type,
@@ -235,9 +235,9 @@ class TestTypes(unittest.TestCase):
             self.assertEqual(type(expected), type(coerced_value))
 
         strings = [
-            u'foo',
-            u'\xe2\x84\xa2',
-            u'Mystery Goo\xe2\x84\xa2 Containment Unit'
+            'foo',
+            '\xe2\x84\xa2',
+            'Mystery Goo\xe2\x84\xa2 Containment Unit'
         ]
         for string in strings:
             self.assertEqual(

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -219,12 +219,12 @@ class Types(object):
         # Collection types
         try:
             # Coerce tuples to lists
-            if isinstance(value, collections.Iterable) and \
+            if isinstance(value, collections.abc.Iterable) and \
                isinstance(typ, ListType):
                 return typ.python_type(
                     self.coerce_to(x, typ.value_type) for x in value)
             # Coerce lists (with appropriate number of elements) to tuples
-            if isinstance(value, collections.Iterable) and \
+            if isinstance(value, collections.abc.Iterable) and \
                isinstance(typ, TupleType):
                 if len(value) != len(typ.value_types):
                     raise ValueError

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -7,9 +7,9 @@ VALUE_TYPES = {
     KRPC.Type.DOUBLE: float,
     KRPC.Type.FLOAT: float,
     KRPC.Type.SINT32: int,
-    KRPC.Type.SINT64: long,
+    KRPC.Type.SINT64: int,
     KRPC.Type.UINT32: int,
-    KRPC.Type.UINT64: long,
+    KRPC.Type.UINT64: int,
     KRPC.Type.BOOL: bool,
     KRPC.Type.STRING: str,
     KRPC.Type.BYTES: bytes
@@ -205,7 +205,7 @@ class Types(object):
         if isinstance(value, typ.python_type):
             return value
         # A unicode type can be coerced to a string
-        if typ.python_type == str and isinstance(value, unicode):
+        if typ.python_type == str and isinstance(value, str):
             return value
         # A NoneType can be coerced to a ClassType
         if isinstance(typ, ClassType) and value is None:
@@ -237,7 +237,7 @@ class Types(object):
                              ' to type ' + str(typ))
         # Numeric types
         # See http://docs.python.org/2/reference/datamodel.html#coercion-rules
-        numeric_types = (float, int, long)
+        numeric_types = (float, int, int)
         if isinstance(value, bool) or \
            not any(isinstance(value, t) for t in numeric_types) or \
            typ.python_type not in numeric_types:
@@ -248,7 +248,7 @@ class Types(object):
             return float(value)
         elif typ.python_type == int:
             return int(value)
-        return long(value)
+        return int(value)
 
 
 class TypeBase(object):
@@ -470,9 +470,9 @@ def _create_class_type(service_name, class_name, doc):
 
 def _create_enum_type(enum_name, values, doc):
     typ = Enum(str(enum_name), dict((name, x['value'])
-                                    for name, x in values.items()))
+                                    for name, x in list(values.items())))
     setattr(typ, '__doc__', doc)
-    for name in values.keys():
+    for name in list(values.keys()):
         setattr(getattr(typ, name), '__doc__', values[name]['doc'])
     return typ
 

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -37,7 +37,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix',

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -32,7 +32,6 @@ setup(
     long_description=open(os.path.join(dirpath, 'README.txt')).read(),
     install_requires=install_requires,
     test_suite='krpc.test',
-    use_2to3=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/client/serialio/setup.py
+++ b/client/serialio/setup.py
@@ -30,7 +30,6 @@ setup(
     long_description=open(os.path.join(dirpath, 'README.txt')).read(),
     install_requires=install_requires,
     test_suite='krpcserialio',
-    use_2to3=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/client/serialio/setup.py
+++ b/client/serialio/setup.py
@@ -35,7 +35,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix',

--- a/client/websockets/setup.py
+++ b/client/websockets/setup.py
@@ -30,7 +30,6 @@ setup(
     long_description=open(os.path.join(dirpath, 'README.txt')).read(),
     install_requires=install_requires,
     test_suite='krpcwebsockets',
-    use_2to3=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/client/websockets/setup.py
+++ b/client/websockets/setup.py
@@ -35,7 +35,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix',

--- a/service/SpaceCenter/test/test_body.py
+++ b/service/SpaceCenter/test/test_body.py
@@ -14,7 +14,7 @@ class TestBody(krpctest.TestCase):
     def test_equality(self):
         bodies = self.space_center.bodies
         bodies2 = self.space_center.bodies
-        for key, body in bodies.items():
+        for key, body in list(bodies.items()):
             self.assertEqual(bodies2[key], body)
 
     def test_kerbin(self):
@@ -170,7 +170,7 @@ class TestBody(krpctest.TestCase):
         self.assertEqual(set(), set(mun.satellites))
 
     def test_position(self):
-        for body in self.space_center.bodies.values():
+        for body in list(self.space_center.bodies.values()):
 
             # Check body position in body's reference frame
             pos = body.position(body.reference_frame)
@@ -187,7 +187,7 @@ class TestBody(krpctest.TestCase):
                 self.assertAlmostEqual(body.orbit.radius, norm(pos), delta=100)
 
     def test_velocity(self):
-        for body in self.space_center.bodies.values():
+        for body in list(self.space_center.bodies.values()):
             if body.orbit is None:
                 continue
 
@@ -219,7 +219,7 @@ class TestBody(krpctest.TestCase):
                 abs(rotational_speed + body.orbit.speed), norm(v), delta=500)
 
     def test_rotation(self):
-        for body in self.space_center.bodies.values():
+        for body in list(self.space_center.bodies.values()):
             # Check body's rotation relative to itself is zero
             r = body.rotation(body.reference_frame)
             # TODO: better test for identity quaternion
@@ -228,7 +228,7 @@ class TestBody(krpctest.TestCase):
             # TODO: more thorough testing
 
     def test_angular_velocity(self):
-        for body in self.space_center.bodies.values():
+        for body in list(self.space_center.bodies.values()):
             # Check body's angular velocity relative to itself is zero
             av = body.angular_velocity(body.reference_frame)
             self.assertAlmostEqual((0, 0, 0), av)

--- a/service/SpaceCenter/test/test_camera.py
+++ b/service/SpaceCenter/test/test_camera.py
@@ -98,8 +98,8 @@ class TestCameraFlight(krpctest.TestCase, CameraTestBase):
         if cls.camera.mode != cls.mode.automatic:
             cls.camera.mode = cls.mode.automatic
         cls.wait(1)
-        cls.pitches = range(-90, 90, 5)
-        cls.headings = range(0, 360, 5)
+        cls.pitches = list(range(-90, 90, 5))
+        cls.headings = list(range(0, 360, 5))
         cls.distances = (1, 5, 10, 20)
 
 
@@ -114,8 +114,8 @@ class TestCameraIVA(krpctest.TestCase, CameraTestBase):
         if cls.camera.mode != cls.mode.iva:
             cls.camera.mode = cls.mode.iva
         cls.wait(1)
-        cls.pitches = range(-30, 30, 5)
-        cls.headings = range(-60, 60, 5)
+        cls.pitches = list(range(-30, 30, 5))
+        cls.headings = list(range(-60, 60, 5))
 
     @classmethod
     def tearDownClass(cls):
@@ -135,8 +135,8 @@ class TestCameraMap(krpctest.TestCase, CameraTestBase):
         if cls.camera.mode != cls.mode.map:
             cls.camera.mode = cls.mode.map
         cls.wait(1)
-        cls.pitches = range(-90, 90, 5)
-        cls.headings = range(0, 360, 5)
+        cls.pitches = list(range(-90, 90, 5))
+        cls.headings = list(range(0, 360, 5))
         cls.distances = (100000, 120000, 200000)
 
     @classmethod

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -252,7 +252,7 @@ class TestControlStaging(krpctest.TestCase):
         self.assertEqual(stage, self.control.current_stage)
 
     def test_staging(self):
-        for i in reversed(range(12)):
+        for i in reversed(list(range(12))):
             self.assertEqual(i, self.control.current_stage)
             self.wait(0.5)
             self.control.activate_next_stage()

--- a/service/SpaceCenter/test/test_parts.py
+++ b/service/SpaceCenter/test/test_parts.py
@@ -45,9 +45,9 @@ class TestParts(krpctest.TestCase):
             'Mk2-R Radial-Mount Parachute',
             'Mk2-R Radial-Mount Parachute',
             'Mk2-R Radial-Mount Parachute',
-            u'Mystery Goo\u2122 Containment Unit ',
-            u'Mystery Goo\u2122 Containment Unit ',
-            u'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
             'OX-STAT Photovoltaic Panels',
             'PresMat Barometer',
             'RE-I5 "Skipper" Liquid Fuel Engine',
@@ -178,9 +178,9 @@ class TestParts(krpctest.TestCase):
             'LT-1 Landing Struts',
             'LY-10 Small Landing Gear',
             'Mk1-2 Command Pod',
-            u'Mystery Goo\u2122 Containment Unit ',
-            u'Mystery Goo\u2122 Containment Unit ',
-            u'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\u2122 Containment Unit ',
             'OX-STAT Photovoltaic Panels',
             'PresMat Barometer',
             'RV-105 RCS Thruster Block',
@@ -303,7 +303,7 @@ class TestParts(krpctest.TestCase):
             ['Mk1-2 Command Pod',
              'GRAVMAX Negative Gravioli Detector',
              'PresMat Barometer'] +
-            [u'Mystery Goo\u2122 Containment Unit ']*3,
+            ['Mystery Goo\u2122 Containment Unit ']*3,
             [p.part.title for p in self.parts.experiments])
 
     def test_fairings(self):

--- a/service/SpaceCenter/test/test_parts.py
+++ b/service/SpaceCenter/test/test_parts.py
@@ -45,9 +45,9 @@ class TestParts(krpctest.TestCase):
             'Mk2-R Radial-Mount Parachute',
             'Mk2-R Radial-Mount Parachute',
             'Mk2-R Radial-Mount Parachute',
-            'Mystery Goo\u2122 Containment Unit ',
-            'Mystery Goo\u2122 Containment Unit ',
-            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
             'OX-STAT Photovoltaic Panels',
             'PresMat Barometer',
             'RE-I5 "Skipper" Liquid Fuel Engine',
@@ -178,9 +178,9 @@ class TestParts(krpctest.TestCase):
             'LT-1 Landing Struts',
             'LY-10 Small Landing Gear',
             'Mk1-2 Command Pod',
-            'Mystery Goo\u2122 Containment Unit ',
-            'Mystery Goo\u2122 Containment Unit ',
-            'Mystery Goo\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
+            'Mystery Goo\\u2122 Containment Unit ',
             'OX-STAT Photovoltaic Panels',
             'PresMat Barometer',
             'RV-105 RCS Thruster Block',
@@ -303,7 +303,7 @@ class TestParts(krpctest.TestCase):
             ['Mk1-2 Command Pod',
              'GRAVMAX Negative Gravioli Detector',
              'PresMat Barometer'] +
-            ['Mystery Goo\u2122 Containment Unit ']*3,
+            ['Mystery Goo\\u2122 Containment Unit ']*3,
             [p.part.title for p in self.parts.experiments])
 
     def test_fairings(self):

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -101,7 +101,7 @@ class EngineTestBase(object):
 
     @classmethod
     def add_engine_data(cls, title, data):
-        for k, v in data.items():
+        for k, v in list(data.items()):
             cls.engine_data[title][k] = v
 
     def get_engine(self, title):
@@ -132,7 +132,7 @@ class EngineTest(EngineTestBase):
         self.assertAlmostEqual(
             data['max_vac_thrust'], engine.max_vacuum_thrust)
         self.assertItemsEqual(
-            data['propellants'].keys(), engine.propellant_names)
+            list(data['propellants'].keys()), engine.propellant_names)
         self.assertAlmostEqual(
             data['propellants'], engine.propellant_ratios, places=3)
         self.assertTrue(engine.has_fuel)
@@ -144,7 +144,7 @@ class EngineTest(EngineTestBase):
         self.assertEqual(data['can_shutdown'], engine.can_shutdown)
         self.assertEqual(data['modes'] is not None, engine.has_modes)
         if data['modes'] is not None:
-            self.assertItemsEqual(data['modes'], engine.modes.keys())
+            self.assertItemsEqual(data['modes'], list(engine.modes.keys()))
             self.assertTrue(engine.mode in data['modes'])
         self.assertEqual(data['gimballed'], engine.gimballed)
         if not data['gimballed']:

--- a/service/SpaceCenter/test/test_parts_experiment.py
+++ b/service/SpaceCenter/test/test_parts_experiment.py
@@ -39,7 +39,7 @@ class TestPartsExperiment(krpctest.TestCase):
 
     def test_goo_container(self):
         self.assertEqual('mysteryGoo', self.goo.name)
-        self.assertEqual(u'Mystery Goo\u2122 Observation', self.goo.title)
+        self.assertEqual('Mystery Goo\u2122 Observation', self.goo.title)
         self.assertFalse(self.goo.deployed)
         self.assertFalse(self.goo.rerunnable)
         self.assertFalse(self.goo.inoperable)
@@ -53,7 +53,7 @@ class TestPartsExperiment(krpctest.TestCase):
         self.assertAlmostEqual(1.0, subject.scientific_value)
         self.assertAlmostEqual(0.3, subject.subject_value)
         self.assertEqual(
-            u'Mystery Goo\u2122 Observation from LaunchPad',
+            'Mystery Goo\u2122 Observation from LaunchPad',
             subject.title)
 
     def test_run_and_dump_data(self):

--- a/service/SpaceCenter/test/test_parts_experiment.py
+++ b/service/SpaceCenter/test/test_parts_experiment.py
@@ -39,7 +39,7 @@ class TestPartsExperiment(krpctest.TestCase):
 
     def test_goo_container(self):
         self.assertEqual('mysteryGoo', self.goo.name)
-        self.assertEqual('Mystery Goo\u2122 Observation', self.goo.title)
+        self.assertEqual('Mystery Goo\\u2122 Observation', self.goo.title)
         self.assertFalse(self.goo.deployed)
         self.assertFalse(self.goo.rerunnable)
         self.assertFalse(self.goo.inoperable)
@@ -53,7 +53,7 @@ class TestPartsExperiment(krpctest.TestCase):
         self.assertAlmostEqual(1.0, subject.scientific_value)
         self.assertAlmostEqual(0.3, subject.subject_value)
         self.assertEqual(
-            'Mystery Goo\u2122 Observation from LaunchPad',
+            'Mystery Goo\\u2122 Observation from LaunchPad',
             subject.title)
 
     def test_run_and_dump_data(self):

--- a/service/SpaceCenter/test/test_parts_part.py
+++ b/service/SpaceCenter/test/test_parts_part.py
@@ -287,9 +287,9 @@ class TestPartsPart(krpctest.TestCase):
         self.assertIsNotNone(part.engine)
 
     def test_experiment(self):
-        part = self.parts.with_title(u'Mystery Goo\u2122 Containment Unit')[0]
+        part = self.parts.with_title('Mystery Goo\u2122 Containment Unit')[0]
         self.assertEqual('GooExperiment', part.name)
-        self.assertEqual(u'Mystery Goo\u2122 Containment Unit', part.title)
+        self.assertEqual('Mystery Goo\u2122 Containment Unit', part.title)
         self.assertEqual(800, part.cost)
         self.assertEqual(self.vessel, part.vessel)
         self.assertEqual('Rockomax X200-32 Fuel Tank', part.parent.title)

--- a/service/SpaceCenter/test/test_parts_part.py
+++ b/service/SpaceCenter/test/test_parts_part.py
@@ -287,9 +287,9 @@ class TestPartsPart(krpctest.TestCase):
         self.assertIsNotNone(part.engine)
 
     def test_experiment(self):
-        part = self.parts.with_title('Mystery Goo\u2122 Containment Unit')[0]
+        part = self.parts.with_title('Mystery Goo\\u2122 Containment Unit')[0]
         self.assertEqual('GooExperiment', part.name)
-        self.assertEqual('Mystery Goo\u2122 Containment Unit', part.title)
+        self.assertEqual('Mystery Goo\\u2122 Containment Unit', part.title)
         self.assertEqual(800, part.cost)
         self.assertEqual(self.vessel, part.vessel)
         self.assertEqual('Rockomax X200-32 Fuel Tank', part.parent.title)

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -30,7 +30,7 @@ class RCSTestBase(object):
 
     @classmethod
     def add_rcs_data(cls, title, data):
-        for k, v in data.items():
+        for k, v in list(data.items()):
             cls.rcs_data[title][k] = v
 
     def get_rcs(self, title):
@@ -82,7 +82,7 @@ class RCSTest(RCSTestBase):
             data['vac_isp'], rcs.vacuum_specific_impulse)
         self.assertEqual(
             data['msl_isp'], rcs.kerbin_sea_level_specific_impulse)
-        self.assertItemsEqual(data['propellants'].keys(), rcs.propellants)
+        self.assertItemsEqual(list(data['propellants'].keys()), rcs.propellants)
         self.assertAlmostEqual(
             data['propellants'], rcs.propellant_ratios, places=3)
         self.assertTrue(rcs.has_fuel)

--- a/service/SpaceCenter/test/test_performance.py
+++ b/service/SpaceCenter/test/test_performance.py
@@ -13,17 +13,17 @@ class TestPerformance(krpctest.TestCase):
             control.throttle = 1
 
         times = [timeit.timeit(stmt=wrapper, number=1) for _ in range(samples)]
-        print('Running', samples, 'RPCs')
-        print('Total execution time:',
-              sum(times), 'seconds')
-        print('Execution rate:      ',
-              samples/sum(times), 'RPCs per second')
-        print('Avg. execution time: ',
-              (sum(times)*1000)/samples, 'milliseconds per RPC')
-        print('Max. execution time: ',
-              max(times)*1000, 'milliseconds per RPC')
-        print('Min. execution time: ',
-              min(times)*1000, 'milliseconds per RPC')
+        print(('Running', samples, 'RPCs'))
+        print(('Total execution time:',
+              sum(times), 'seconds'))
+        print(('Execution rate:      ',
+              samples/sum(times), 'RPCs per second'))
+        print(('Avg. execution time: ',
+              (sum(times)*1000)/samples, 'milliseconds per RPC'))
+        print(('Max. execution time: ',
+              max(times)*1000, 'milliseconds per RPC'))
+        print(('Min. execution time: ',
+              min(times)*1000, 'milliseconds per RPC'))
 
 
 if __name__ == '__main__':

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -29,11 +29,11 @@ class TestReferenceFrame(krpctest.TestCase):
             self.assertAlmostEqual(expected_pos, actual_pos, delta=1)
 
     def test_celestial_body_position(self):
-        for body in self.bodies.values():
+        for body in list(self.bodies.values()):
             self.check_object_position(body, body.reference_frame)
 
     def test_celestial_body_orbital_position(self):
-        for body in self.bodies.values():
+        for body in list(self.bodies.values()):
             if body.orbit is not None:
                 self.check_object_position(body, body.orbital_reference_frame)
             else:
@@ -111,12 +111,12 @@ class TestReferenceFrame(krpctest.TestCase):
                 abs(rotational_speed + obj.orbit.speed), norm(v), delta=200)
 
     def test_celestial_body_velocity(self):
-        for body in self.bodies.values():
+        for body in list(self.bodies.values()):
             self.check_object_velocity(body, body.reference_frame)
             self.check_object_surface_velocity(body, body.reference_frame)
 
     def test_celestial_body_orbital_velocity(self):
-        for body in self.bodies.values():
+        for body in list(self.bodies.values()):
             if body.orbit is not None:
                 self.check_object_velocity(body, body.orbital_reference_frame)
                 self.check_object_surface_velocity(
@@ -155,7 +155,7 @@ class TestReferenceFrame(krpctest.TestCase):
 
     def test_celestial_body_direction(self):
         # Check (0, 1, 0) direction same as body direction
-        for body in self.bodies.values():
+        for body in list(self.bodies.values()):
             self.assertAlmostEqual(
                 (0, 1, 0), body.direction(body.reference_frame))
 

--- a/service/SpaceCenter/test/test_resources.py
+++ b/service/SpaceCenter/test/test_resources.py
@@ -20,7 +20,7 @@ class TestResources(krpctest.TestCase, ResourcesTest):
         if cls.connect().space_center.active_vessel.name != 'Resources':
             cls.launch_vessel_from_vab('Resources')
         cls.vessel = cls.connect().space_center.active_vessel
-        cls.num_stages = len(cls.expected.keys())-1
+        cls.num_stages = len(list(cls.expected.keys()))-1
 
     expected = {
         -1: {
@@ -228,7 +228,7 @@ class TestResourcesStaticMethods(krpctest.TestCase, ResourcesTest):
         cls.resources = cls.connect().space_center.Resources
 
     def test_density(self):
-        for name, expected in self.density.items():
+        for name, expected in list(self.density.items()):
             self.assertEqual(expected, self.resources.density(name))
         self.assertRaises(ValueError, self.resources.density, 'Foo')
 

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -216,12 +216,12 @@ class TestVesselEngines(krpctest.TestCase):
                 'msl_isp': 0
             }
         }
-        max_thrusts = [x['max_thrust'] for x in cls.engine_info.values()]
+        max_thrusts = [x['max_thrust'] for x in list(cls.engine_info.values())]
         available_thrusts = [x['available_thrust']
-                             for x in cls.engine_info.values()]
-        isps = [x['isp'] for x in cls.engine_info.values()]
-        vac_isps = [x['vac_isp'] for x in cls.engine_info.values()]
-        msl_isps = [x['msl_isp'] for x in cls.engine_info.values()]
+                             for x in list(cls.engine_info.values())]
+        isps = [x['isp'] for x in list(cls.engine_info.values())]
+        vac_isps = [x['vac_isp'] for x in list(cls.engine_info.values())]
+        msl_isps = [x['msl_isp'] for x in list(cls.engine_info.values())]
         cls.max_thrust = sum(max_thrusts)
         cls.available_thrust = sum(available_thrusts)
         cls.combined_isp = \

--- a/tools/dist/changes.py
+++ b/tools/dist/changes.py
@@ -39,30 +39,30 @@ def main():
             changelist.append((name, changes[args.version]))
 
     if args.site == 'github':
-        print(''.join(open('tools/dist/github-changes.tmpl', 'r').readlines()).replace('%VERSION%', args.version))
+        print((''.join(open('tools/dist/github-changes.tmpl', 'r').readlines()).replace('%VERSION%', args.version)))
         print('### Changes ###\n')
     if args.site == 'github':
         for name,items in changelist:
-            print('#### '+ name + ' ####\n')
+            print(('#### '+ name + ' ####\n'))
             for item in items:
-                print('* ' + item)
+                print(('* ' + item))
             print('')
     elif args.site == 'spacedock':
         for name,items in changelist:
-            print('#### '+ name + ' ####\n')
+            print(('#### '+ name + ' ####\n'))
             for item in items:
                 pattern = re.compile(r'#([0-9]+)')
                 item = pattern.sub(r'[#\1](https://github.com/krpc/krpc/issues/\1)', item)
-                print('* ' + item)
+                print(('* ' + item))
             print('')
     else: # curse
         print('<ul>')
         for name,items in changelist:
-            print('<li>'+name+'<ul>')
+            print(('<li>'+name+'<ul>'))
             for item in items:
                 pattern = re.compile(r'#([0-9]+)')
                 item = pattern.sub(r'<a href="https://github.com/krpc/krpc/issues/\1">#\1</a>', item)
-                print('<li>'+item+'</li>')
+                print(('<li>'+item+'</li>'))
             print('</ul></li>')
         print('</ul>')
 
@@ -84,7 +84,7 @@ def get_changes(path):
             elif line.startswith('   '):
                 changes[version][-1] += line[2:]
             else:
-                print('Invalid line in ' + path + ':')
+                print(('Invalid line in ' + path + ':'))
                 print(line)
                 exit(1)
     return changes

--- a/tools/do-serve-docs.py
+++ b/tools/do-serve-docs.py
@@ -49,7 +49,7 @@ class UpdateStagedFiles(pyinotify.ProcessEvent):
             for filename in filenames:
                 path = os.path.relpath(os.path.join(basepath, filename), stage)
                 if not os.path.exists(os.path.join(src, path)):
-                    print 'Removing', path
+                    print('Removing', path)
                     os.unlink(os.path.join(stage, path))
 
         # Update stale files in stage directory
@@ -60,12 +60,12 @@ class UpdateStagedFiles(pyinotify.ProcessEvent):
                 srcpath = os.path.join(src, path)
                 stagepath = os.path.join(stage, path)
                 if not os.path.exists(stagepath):
-                    print 'Staging new file', path
+                    print('Staging new file', path)
                     if not os.path.exists(os.path.dirname(stagepath)):
                         os.makedirs(os.path.dirname(stagepath))
                     shutil.copy(srcpath, stagepath)
                 elif not filecmp.cmp(srcpath, stagepath):
-                    print 'Updating file', path
+                    print('Updating file', path)
                     os.unlink(stagepath)
                     shutil.copy(srcpath, stagepath)
 

--- a/tools/krpctest/krpctest/__init__.py
+++ b/tools/krpctest/krpctest/__init__.py
@@ -195,7 +195,7 @@ class TestCase(unittest.TestCase):
     def _dict_is_almost_equal(self, second, first, places, delta=None):
         if set(second.keys()) != set(first.keys()):
             return False
-        for k in second.keys():
+        for k in list(second.keys()):
             if not self._is_almost_equal(
                     second[k], first[k], places, delta):
                 return False

--- a/tools/krpctest/setup.py
+++ b/tools/krpctest/setup.py
@@ -28,7 +28,6 @@ setup(
     package_data={'': ['krpctest.sfs', 'krpctest_career.sfs']},
     install_requires=install_requires,
     test_suite='krpctest.test',
-    use_2to3=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/tools/krpctest/setup.py
+++ b/tools/krpctest/setup.py
@@ -33,7 +33,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix'

--- a/tools/krpctools/krpctools/clientgen/__init__.py
+++ b/tools/krpctools/krpctools/clientgen/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import importlib
 import json
@@ -96,9 +96,9 @@ def main():
                 '\',\''.join(inputs))
 
         # Check loaded definitions
-        if not defs.keys():
+        if not list(defs.keys()):
             raise RuntimeError('No services found in input.')
-        if args.service not in defs.keys():
+        if args.service not in list(defs.keys()):
             raise RuntimeError(
                 'Service \'%s\' not found in input.' % args.service)
 
@@ -119,7 +119,7 @@ def main():
         else:
             print(g.generate())
 
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write('Error: %s\n' % str(ex))
         return 1
 

--- a/tools/krpctools/krpctools/clientgen/__init__.py
+++ b/tools/krpctools/krpctools/clientgen/__init__.py
@@ -117,7 +117,7 @@ def main():
         if args.output:
             g.generate_file(args.output)
         else:
-            print(g.generate())
+            print((g.generate()))
 
     except RuntimeError as ex:
         sys.stderr.write('Error: %s\n' % str(ex))

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -158,7 +158,7 @@ class CnanoGenerator(Generator):
             return typ
 
         properties = collections.OrderedDict()
-        for name, info in context['properties'].items():
+        for name, info in list(context['properties'].items()):
             if info['getter']:
                 properties[name] = {
                     'remote_id': info['getter']['remote_id'],
@@ -176,9 +176,9 @@ class CnanoGenerator(Generator):
                     'documentation': info['documentation']
                 }
 
-        for _, class_info in context['classes'].items():
+        for _, class_info in list(context['classes'].items()):
             class_properties = collections.OrderedDict()
-            for name, info in class_info['properties'].items():
+            for name, info in list(class_info['properties'].items()):
                 if info['getter']:
                     class_properties[name] = {
                         'remote_id': info['getter']['remote_id'],

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -31,12 +31,12 @@ class CppGenerator(Generator):
         return '\n'.join(line.rstrip() for line in lines)
 
     def parse_context(self, context):
-        for info in context['procedures'].values():
+        for info in list(context['procedures'].values()):
             info['return_set_client'] = self.parse_set_client(
                 info['procedure'])
 
         properties = collections.OrderedDict()
-        for name, info in context['properties'].items():
+        for name, info in list(context['properties'].items()):
             if info['getter']:
                 properties[name] = {
                     'remote_name': info['getter']['remote_name'],
@@ -56,17 +56,17 @@ class CppGenerator(Generator):
                     'documentation': info['documentation']
                 }
 
-        for class_info in context['classes'].values():
-            for info in class_info['methods'].values():
+        for class_info in list(context['classes'].values()):
+            for info in list(class_info['methods'].values()):
                 info['return_set_client'] = self.parse_set_client(
                     info['procedure'])
 
-            for info in class_info['static_methods'].values():
+            for info in list(class_info['static_methods'].values()):
                 info['return_set_client'] = self.parse_set_client(
                     info['procedure'])
 
             class_properties = collections.OrderedDict()
-            for name, info in class_info['properties'].items():
+            for name, info in list(class_info['properties'].items()):
                 if info['getter']:
                     class_properties[name] = {
                         'remote_name': info['getter']['remote_name'],

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -59,7 +59,7 @@ class Generator(object):
         return parameters
 
     def _get_defs(self, key):
-        return self._defs.get(key, {}).items()
+        return list(self._defs.get(key, {}).items())
 
     def generate_context(self):
         context = {
@@ -225,14 +225,14 @@ class Generator(object):
         # Sort the context
         def sort_dict(x):
             return collections.OrderedDict(
-                sorted(x.items(), key=lambda x: x[0]))
+                sorted(list(x.items()), key=lambda x: x[0]))
 
         context['procedures'] = sort_dict(context['procedures'])
         context['properties'] = sort_dict(context['properties'])
         context['enumerations'] = sort_dict(context['enumerations'])
         context['classes'] = sort_dict(context['classes'])
         context['exceptions'] = sort_dict(context['exceptions'])
-        for cls in context['classes'].values():
+        for cls in list(context['classes'].values()):
             cls['methods'] = sort_dict(cls['methods'])
             cls['static_methods'] = sort_dict(cls['static_methods'])
             cls['properties'] = sort_dict(cls['properties'])

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -60,7 +60,7 @@ class JavaGenerator(Generator):
     def parse_context(self, context):
         # Expand service properties into get and set methods
         properties = collections.OrderedDict()
-        for name, info in context['properties'].items():
+        for name, info in list(context['properties'].items()):
             if info['getter']:
                 properties['get'+upper_camel_case(name)] = {
                     'procedure': info['getter']['procedure'],
@@ -81,9 +81,9 @@ class JavaGenerator(Generator):
         context['properties'] = properties
 
         # Expand class properties into get and set methods
-        for class_name, class_info in context['classes'].items():
+        for class_name, class_info in list(context['classes'].items()):
             class_properties = collections.OrderedDict()
-            for name, info in class_info['properties'].items():
+            for name, info in list(class_info['properties'].items()):
                 if info['getter']:
                     class_properties['get'+upper_camel_case(name)] = {
                         'procedure': info['getter']['procedure'],
@@ -106,11 +106,11 @@ class JavaGenerator(Generator):
 
         # Add type specifications to types
         procedures = \
-            context['procedures'].values() + \
-            context['properties'].values() + \
+            list(context['procedures'].values()) + \
+            list(context['properties'].values()) + \
             list(itertools.chain(
-                *[class_info['static_methods'].values()
-                  for class_info in context['classes'].values()]))
+                *[list(class_info['static_methods'].values())
+                  for class_info in list(context['classes'].values())]))
         for info in procedures:
             info['return_type'] = {
                 'name': info['return_type'],
@@ -127,9 +127,9 @@ class JavaGenerator(Generator):
                 }
                 pos += 1
 
-        for class_info in context['classes'].values():
-            items = class_info['methods'].values() + \
-                    class_info['properties'].values()
+        for class_info in list(context['classes'].values()):
+            items = list(class_info['methods'].values()) + \
+                    list(class_info['properties'].values())
             for info in items:
                 info['return_type'] = {
                     'name': info['return_type'],
@@ -148,13 +148,13 @@ class JavaGenerator(Generator):
                     pos += 1
 
         # Make enumeration members UPPER_SNAKE_CASE
-        for enm in context['enumerations'].values():
+        for enm in list(context['enumerations'].values()):
             for value in enm['values']:
                 value['name'] = self.language.parse_const_name(value['name'])
 
         # Add serial version UIDs to classes
-        items = context['classes'].items() + \
-            context['exceptions'].items()
+        items = list(context['classes'].items()) + \
+            list(context['exceptions'].items())
         for class_name, cls in items:
             tohash = self.service_name+'.'+class_name
             hsh = hashlib.sha1(tohash.encode('utf-8')).hexdigest()

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -44,7 +44,7 @@ class PythonGenerator(Generator):
     def parse_context(self, context):
         # Expand service properties into get and set methods
         properties = collections.OrderedDict()
-        for name, info in context['properties'].items():
+        for name, info in list(context['properties'].items()):
             if name not in properties:
                 properties[name] = {}
 
@@ -68,9 +68,9 @@ class PythonGenerator(Generator):
         context['properties'] = properties
 
         # Expand class properties into get and set methods
-        for class_info in context['classes'].values():
+        for class_info in list(context['classes'].values()):
             class_properties = collections.OrderedDict()
-            for name, info in class_info['properties'].items():
+            for name, info in list(class_info['properties'].items()):
                 if name not in class_properties:
                     class_properties[name] = {}
                 if info['getter']:
@@ -96,13 +96,13 @@ class PythonGenerator(Generator):
         # Find all service dependencies
         dependencies = set()
         procedures = \
-            context['procedures'].values() + \
+            list(context['procedures'].values()) + \
             [procedure
-             for property in context['properties'].values()
-             for procedure in property.values()] + \
+             for property in list(context['properties'].values())
+             for procedure in list(property.values())] + \
             list(itertools.chain(
-                *[class_info['static_methods'].values()
-                  for class_info in context['classes'].values()]))
+                *[list(class_info['static_methods'].values())
+                  for class_info in list(context['classes'].values())]))
         for info in procedures:
             if 'return_type' in info['procedure']:
                 rtype = info['procedure']['return_type']
@@ -115,11 +115,11 @@ class PythonGenerator(Generator):
                         and context['service_name'] != ptype['service']:
                     dependencies.add(ptype['service'])
 
-        for class_info in context['classes'].values():
-            items = class_info['methods'].values() + \
+        for class_info in list(context['classes'].values()):
+            items = list(class_info['methods'].values()) + \
                     [procedure
-                     for property in class_info['properties'].values()
-                     for procedure in property.values()]
+                     for property in list(class_info['properties'].values())
+                     for procedure in list(property.values())]
             for info in items:
                 if 'return_type' in info['procedure']:
                     rtype = info['procedure']['return_type']
@@ -135,13 +135,13 @@ class PythonGenerator(Generator):
 
         # Add type specifications to types
         procedures = \
-            context['procedures'].values() + \
+            list(context['procedures'].values()) + \
             [procedure
-             for property in context['properties'].values()
-             for _, procedure in property.items()] + \
+             for property in list(context['properties'].values())
+             for _, procedure in list(property.items())] + \
             list(itertools.chain(
-                *[class_info['static_methods'].values()
-                  for class_info in context['classes'].values()]))
+                *[list(class_info['static_methods'].values())
+                  for class_info in list(context['classes'].values())]))
         for info in procedures:
             info['return_type'] = {
                 'name': info['return_type'],
@@ -158,11 +158,11 @@ class PythonGenerator(Generator):
                 }
                 pos += 1
 
-        for class_info in context['classes'].values():
-            items = class_info['methods'].values() + \
+        for class_info in list(context['classes'].values()):
+            items = list(class_info['methods'].values()) + \
                     [procedure
-                     for property in class_info['properties'].values()
-                     for _, procedure in property.items()]
+                     for property in list(class_info['properties'].values())
+                     for _, procedure in list(property.items())]
             for info in items:
                 info['return_type'] = {
                     'name': info['return_type'],

--- a/tools/krpctools/krpctools/docgen/__init__.py
+++ b/tools/krpctools/krpctools/docgen/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import glob
 import os
@@ -103,7 +103,7 @@ def main():
         return info
 
     services = {name: Service(name, sort=sort, **parse_service_info(info))
-                for name, info in services_info.items()}
+                for name, info in list(services_info.items())}
 
     if sort_failed:
         raise RuntimeError(

--- a/tools/krpctools/krpctools/docgen/cpp.py
+++ b/tools/krpctools/krpctools/docgen/cpp.py
@@ -95,7 +95,7 @@ class CppDomain(Domain):
         elif isinstance(typ, DictionaryType):
             entries = ('{%s, %s}' % (self.default_value(k, typ.key_type),
                                      self.default_value(v, typ.value_type))
-                       for k, v in value.items())
+                       for k, v in list(value.items()))
             return '%s(%s)' % (self.language.parse_type(typ),
                                ', '.join(entries))
         return self.language.parse_default_value(value, typ)

--- a/tools/krpctools/krpctools/docgen/csharp.py
+++ b/tools/krpctools/krpctools/docgen/csharp.py
@@ -64,7 +64,7 @@ class CsharpDomain(Domain):
             entries = ('%s: %s' %
                        (self.default_value(k, typ.key_type),
                         self.default_value(v, typ.value_type))
-                       for k, v in value.items())
+                       for k, v in list(value.items()))
             return '{ %s }' % ', '.join(entries)
         return self.language.parse_default_value(value, typ)
 

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -32,7 +32,7 @@ class Service(Appendable):
         cprocedures = defaultdict(dict)
         properties = defaultdict(dict)
 
-        for pname, info in procedures.iteritems():
+        for pname, info in procedures.items():
             del info['id']
 
             if 'game_scenes' in info:
@@ -57,18 +57,18 @@ class Service(Appendable):
                 cname = Attributes.get_class_name(pname)
                 cprocedures[cname][pname] = info
 
-        for propname, prop in properties.iteritems():
+        for propname, prop in properties.items():
             members.append(Property(name, propname, **prop))
 
         self.classes = {
             cname: Class(name, cname, cprocedures[cname], sort=sort, **cinfo)
-            for (cname, cinfo) in classes.iteritems()}
+            for (cname, cinfo) in classes.items()}
         self.enumerations = {
             ename: Enumeration(name, ename, sort=sort, **einfo)
-            for (ename, einfo) in enumerations.iteritems()}
+            for (ename, einfo) in enumerations.items()}
         self.exceptions = {
             ename: ExceptionNode(name, ename, **einfo)
-            for (ename, einfo) in exceptions.iteritems()}
+            for (ename, einfo) in exceptions.items()}
 
         self.members = OrderedDict(
             (member.name, member) for member in sorted(members, key=sort))
@@ -95,7 +95,7 @@ class Class(Appendable):
         members = []
         properties = defaultdict(dict)
 
-        for pname, pinfo in procedures.iteritems():
+        for pname, pinfo in procedures.items():
             if 'id' in pinfo:
                 del pinfo['id']
 
@@ -114,7 +114,7 @@ class Class(Appendable):
                 else:
                     properties[propname]['setter'] = proc
 
-        for propname, prop in properties.iteritems():
+        for propname, prop in properties.items():
             members.append(ClassProperty(service_name, name, propname, **prop))
 
         self.members = OrderedDict((member.name, member)

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -32,7 +32,7 @@ class Service(Appendable):
         cprocedures = defaultdict(dict)
         properties = defaultdict(dict)
 
-        for pname, info in procedures.items():
+        for pname, info in list(procedures.items()):
             del info['id']
 
             if 'game_scenes' in info:
@@ -57,18 +57,18 @@ class Service(Appendable):
                 cname = Attributes.get_class_name(pname)
                 cprocedures[cname][pname] = info
 
-        for propname, prop in properties.items():
+        for propname, prop in list(properties.items()):
             members.append(Property(name, propname, **prop))
 
         self.classes = {
             cname: Class(name, cname, cprocedures[cname], sort=sort, **cinfo)
-            for (cname, cinfo) in classes.items()}
+            for (cname, cinfo) in list(classes.items())}
         self.enumerations = {
             ename: Enumeration(name, ename, sort=sort, **einfo)
-            for (ename, einfo) in enumerations.items()}
+            for (ename, einfo) in list(enumerations.items())}
         self.exceptions = {
             ename: ExceptionNode(name, ename, **einfo)
-            for (ename, einfo) in exceptions.items()}
+            for (ename, einfo) in list(exceptions.items())}
 
         self.members = OrderedDict(
             (member.name, member) for member in sorted(members, key=sort))
@@ -95,7 +95,7 @@ class Class(Appendable):
         members = []
         properties = defaultdict(dict)
 
-        for pname, pinfo in procedures.items():
+        for pname, pinfo in list(procedures.items()):
             if 'id' in pinfo:
                 del pinfo['id']
 
@@ -114,7 +114,7 @@ class Class(Appendable):
                 else:
                     properties[propname]['setter'] = proc
 
-        for propname, prop in properties.items():
+        for propname, prop in list(properties.items()):
             members.append(ClassProperty(service_name, name, propname, **prop))
 
         self.members = OrderedDict((member.name, member)

--- a/tools/krpctools/krpctools/docgen/utils.py
+++ b/tools/krpctools/krpctools/docgen/utils.py
@@ -1,17 +1,17 @@
 def lookup_cref(cref, services):
     if lookup_cref.services_lookup is None:
         objs = []
-        for service in services.values():
+        for service in list(services.values()):
             objs.append(service)
-            objs.extend(service.members.values())
-            objs.extend(service.classes.values())
-            objs.extend(service.enumerations.values())
-            objs.extend(service.exceptions.values())
-            for cls in service.classes.values():
-                objs.extend(cls.members.values())
-            for enumeration in service.enumerations.values():
-                objs.extend(enumeration.values.values())
-                for value in enumeration.values.values():
+            objs.extend(list(service.members.values()))
+            objs.extend(list(service.classes.values()))
+            objs.extend(list(service.enumerations.values()))
+            objs.extend(list(service.exceptions.values()))
+            for cls in list(service.classes.values()):
+                objs.extend(list(cls.members.values()))
+            for enumeration in list(service.enumerations.values()):
+                objs.extend(list(enumeration.values.values()))
+                for value in list(enumeration.values.values()):
                     objs.append(value)
         lookup_cref.services_lookup = dict([(x.cref, x) for x in objs])
     return lookup_cref.services_lookup[cref]

--- a/tools/krpctools/krpctools/lang/cpp.py
+++ b/tools/krpctools/krpctools/lang/cpp.py
@@ -100,7 +100,7 @@ class CppLanguage(Language):
             entries = ('{%s, %s}' %
                        (self.parse_default_value(k, typ.key_type),
                         self.parse_default_value(v, typ.value_type))
-                       for k, v in value.items())
+                       for k, v in list(value.items()))
             return '%s{%s}' % (self.parse_type(typ), ', '.join(entries))
         return str(value)
 

--- a/tools/krpctools/krpctools/lang/csharp.py
+++ b/tools/krpctools/krpctools/lang/csharp.py
@@ -112,7 +112,7 @@ class CsharpLanguage(Language):
             entries = ('{ %s, %s }' %
                        (self.parse_default_value(k, typ.key_type),
                         self.parse_default_value(v, typ.value_type))
-                       for k, v in value.items())
+                       for k, v in list(value.items()))
             return 'new %s {%s}' % \
                 (self._parse_type(typ, False), ', '.join(entries))
         return str(value)

--- a/tools/krpctools/krpctools/servicedefs/__init__.py
+++ b/tools/krpctools/krpctools/servicedefs/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import json
 import os
@@ -34,7 +34,7 @@ def main():
 
     try:
         defs = servicedefs(args.ksp, args.service, args.assemblies)
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("Error: %s\n" % str(ex))
         return 1
 
@@ -85,7 +85,7 @@ def servicedefs(ksp, service, assemblies):
             [bindir+'/ServiceDefinitions.exe',
              '--output=%s' % tmpout, service] + assemblies,
             stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError, ex:
+    except subprocess.CalledProcessError as ex:
         raise RuntimeError(ex.output)
 
     with open(tmpout, 'r') as fp:

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -27,7 +27,7 @@ class DocGenTestCase(object):
             return info
 
         services = {name: Service(name, sort=sort, **parse_service_info(info))
-                    for name, info in defs.items()}
+                    for name, info in list(defs.items())}
 
         rst_content = [
             '.. default-domain:: {{ domain.sphinxname }}',

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -27,7 +27,7 @@ class DocGenTestCase(object):
             return info
 
         services = {name: Service(name, sort=sort, **parse_service_info(info))
-                    for name, info in defs.iteritems()}
+                    for name, info in defs.items()}
 
         rst_content = [
             '.. default-domain:: {{ domain.sphinxname }}',
@@ -38,15 +38,15 @@ class DocGenTestCase(object):
             '',
             '{{ macros.service(services[\'%s\']) }}' % service_name
         ]
-        for cls in defs[service_name]['classes'].keys():
+        for cls in list(defs[service_name]['classes'].keys()):
             rst_content.append(
                 "{{ macros.class(services['%s'].classes['%s']) }}"
                 % (service_name, cls))
-        for enm in defs[service_name]['enumerations'].keys():
+        for enm in list(defs[service_name]['enumerations'].keys()):
             rst_content.append(
                 "{{ macros.enumeration(services['%s'].enumerations['%s']) }}"
                 % (service_name, enm))
-        for exn in defs[service_name]['exceptions'].keys():
+        for exn in list(defs[service_name]['exceptions'].keys()):
             rst_content.append(
                 "{{ macros.exception(services['%s'].exceptions['%s']) }}"
                 % (service_name, exn))

--- a/tools/krpctools/setup.py
+++ b/tools/krpctools/setup.py
@@ -43,7 +43,6 @@ setup(
                        'bin/*.exe', 'bin/*.dll', 'bin/*.xml', 'bin/*.zip']},
     install_requires=install_requires,
     test_suite='krpctools.test',
-    use_2to3=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/tools/krpctools/setup.py
+++ b/tools/krpctools/setup.py
@@ -48,7 +48,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: Unix',

--- a/tools/travis-ci/set-version.py
+++ b/tools/travis-ci/set-version.py
@@ -43,7 +43,7 @@ else:
 
 # Compute version string
 version = '%s-%s-%s' % version
-print('version =', version)
+print(('version =', version))
 
 # Update config.bzl
 with open('config.bzl', 'r') as f:

--- a/tools/update-workspace.py
+++ b/tools/update-workspace.py
@@ -24,7 +24,7 @@ def read_workspace():
         line = lines[i]
 
         def error(msg):
-            print('ERROR on line %d' % i)
+            print(('ERROR on line %d' % i))
             print(msg)
             exit(1)
 
@@ -86,7 +86,7 @@ def write_workspace(header, loads, workspace):
     for entry in workspace:
         lines.append('')
         lines.append(entry['type']+'(')
-        props = ['    %s = %s' % entry for entry in entry['props'].items()]
+        props = ['    %s = %s' % entry for entry in list(entry['props'].items())]
         lines.append(',\n'.join(props))
         lines.append(')')
     with open('WORKSPACE', 'w') as f:
@@ -163,14 +163,14 @@ def main():
             package, version, typ = parse_python_package(path)
             versions = get_python_package_versions(package, typ)
             try:
-                latest_version = sorted(versions.keys(), key=distutils.version.LooseVersion)[-1]
+                latest_version = sorted(list(versions.keys()), key=distutils.version.LooseVersion)[-1]
             except TypeError:
                 latest_version = list(versions.keys())[-1]
             path = '[\'%s\']' % versions[latest_version]
             if props['urls'] == path:
-                print(props['name'][1:-1], 'is up to date')
+                print((props['name'][1:-1], 'is up to date'))
             else:
-                print('Updating', props['name'][1:-1], 'to', latest_version)
+                print(('Updating', props['name'][1:-1], 'to', latest_version))
                 props['urls'] = path
                 result = urllib.request.urlretrieve(props['urls'][2:-2])
                 entry['props']['sha256'] = '\'%s\'' % sha256file(result[0])


### PR DESCRIPTION
Mostly just running the `2to3` automatic translator, but also use `collections.abc.Iterable` (Python 3.3, I think) instead of `collections.Iterable`, and superficially update the `setup.py`s to run and not contain obviously incorrect version info.

Gets the two tutorial scripts working in Python 3. Expect this to completely break Python 2, however. But 2's very much EOL anyway.

See commit history for detailed changes and notes.