### PR TITLE
Add KSP 1.7.1 Custom axis groups support.

### DIFF
--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -21,6 +21,7 @@ namespace KRPC.SpaceCenter
         internal sealed class ControlInputs
         {
             readonly FlightCtrlState state;
+            AxisGroupsModule axisModule;
 
             public ControlInputs ()
             {
@@ -29,6 +30,7 @@ namespace KRPC.SpaceCenter
                 ThrottleUpdated = false;
                 WheelThrottleUpdated = false;
                 WheelSteerUpdated = false;
+                axisModule = FlightGlobals.ActiveVessel.FindVesselModuleImplementing<AxisGroupsModule>();
             }
 
             public ControlInputs (FlightCtrlState ctrlState)
@@ -102,6 +104,34 @@ namespace KRPC.SpaceCenter
 
             public bool WheelSteerUpdated { get; set; }
 
+            public float CustomAxis01 {
+                get { return state.custom_axes[0]; }
+                set {
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom01, value.Clamp (-1f, 1f));
+                }
+            }
+
+            public float CustomAxis02 {
+                get { return state.custom_axes[1]; }
+                set {
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom02, value.Clamp (-1f, 1f));
+                }
+            }
+
+            public float CustomAxis03 {
+                get { return state.custom_axes[2]; }
+                set {
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom03, value.Clamp (-1f, 1f));
+                }
+            }
+
+            public float CustomAxis04 {
+                get { return state.custom_axes[3]; }
+                set {
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom04, value.Clamp (-1f, 1f));
+                }
+            }
+
             public void ClearExceptThrottle ()
             {
                 state.roll = 0f;
@@ -112,6 +142,10 @@ namespace KRPC.SpaceCenter
                 state.Z = 0f;
                 state.wheelThrottle = 0f;
                 state.wheelSteer = 0f;
+                state.custom_axes[0] = 0f;
+                state.custom_axes[1] = 0f;
+                state.custom_axes[2] = 0f;
+                state.custom_axes[3] = 0f;
             }
 
             [SuppressMessage ("Gendarme.Rules.Smells", "AvoidLongMethodsRule")]
@@ -127,6 +161,10 @@ namespace KRPC.SpaceCenter
                     state.X += other.state.X;
                     state.Y += other.state.Y;
                     state.Z += other.state.Z;
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom01, state.custom_axes[0] + other.state.custom_axes[0]);
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom02, state.custom_axes[1] + other.state.custom_axes[1]);
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom03, state.custom_axes[2] + other.state.custom_axes[2]);
+                    axisModule.SetAxisGroup(KSPAxisGroup.Custom04, state.custom_axes[3] + other.state.custom_axes[3]);
                 } else {
                     if (Math.Abs(other.state.pitch) > 0.001)
                         state.pitch = other.state.pitch;
@@ -140,6 +178,14 @@ namespace KRPC.SpaceCenter
                         state.Y = other.state.Y;
                     if (Math.Abs(other.state.Z) > 0.001)
                         state.Z = other.state.Z;
+                    if (Math.Abs(other.state.custom_axes[0]) > 0.001)
+                        axisModule.SetAxisGroup(KSPAxisGroup.Custom01, other.state.custom_axes[0]);
+                    if (Math.Abs(other.state.custom_axes[1]) > 0.001)
+                        axisModule.SetAxisGroup(KSPAxisGroup.Custom02, other.state.custom_axes[1]);
+                    if (Math.Abs(other.state.custom_axes[2]) > 0.001)
+                        axisModule.SetAxisGroup(KSPAxisGroup.Custom03, other.state.custom_axes[2]);
+                    if (Math.Abs(other.state.custom_axes[3]) > 0.001)
+                        axisModule.SetAxisGroup(KSPAxisGroup.Custom04, other.state.custom_axes[3]);
                 }
                 if (other.WheelThrottleUpdated)
                     state.wheelThrottle = other.state.wheelThrottle;

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -464,6 +464,43 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The state of CustomAxis01.
+        /// A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float CustomAxis01 {
+            get { return PilotAddon.Get (InternalVessel).CustomAxis01; }
+            set { PilotAddon.Set (InternalVessel).CustomAxis01 = value; }
+        }
+        /// <summary>
+        /// The state of CustomAxis02.
+        /// A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float CustomAxis02 {
+            get { return PilotAddon.Get (InternalVessel).CustomAxis02; }
+            set { PilotAddon.Set (InternalVessel).CustomAxis02 = value; }
+        }
+        /// <summary>
+        /// The state of CustomAxis03.
+        /// A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float CustomAxis03 {
+            get { return PilotAddon.Get (InternalVessel).CustomAxis03; }
+            set { PilotAddon.Set (InternalVessel).CustomAxis03 = value; }
+        }
+        /// <summary>
+        /// The state of CustomAxis04.
+        /// A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float CustomAxis04 {
+            get { return PilotAddon.Get (InternalVessel).CustomAxis04; }
+            set { PilotAddon.Set (InternalVessel).CustomAxis04 = value; }
+        }
+
+        /// <summary>
         /// The current stage of the vessel. Corresponds to the stage number in
         /// the in-game UI.
         /// </summary>


### PR DESCRIPTION
This adds support for the 4x custom axes introduced in KSP 1.7.1, mimicking the other axis inputs. Only tested lightly via the python client. The trivial approach of just setting the values via the state variable doesn't work, but thankfully, X52 on the KSP forums figured out a path that worked:

https://forum.kerbalspaceprogram.com/index.php?/topic/200955-cant-change-custom_axes-from-code-solved/#comment-3939362
